### PR TITLE
Add serverless skeleton with OpenFaaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Data-Driven Intelligence Platform Skeleton
+
+This repository provides a minimal skeleton for a serverless, data-driven
+intelligence platform built on top of OpenFaaS. The platform accepts YAML
+pipelines describing data processing steps and orchestrates them via
+functions. This code is only a starting point for further development.
+
+## Functions
+
+### Bridge API
+
+* Location: `faas/bridge-api`
+* Accepts a YAML pipeline and publishes it to Kafka.
+* Manifest: `faas/bridge-api.yml`
+
+### Crawler
+
+* Location: `faas/crawler`
+* Placeholder implementation of a data crawler function.
+
+## OpenFaaS Deployment
+
+Deploy both functions using the OpenFaaS CLI:
+
+```bash
+faas-cli deploy -f faas/bridge-api.yml
+```
+
+## Database Schema
+
+The `schema/postgres.sql` file contains a simple schema for managing
+multi-tenant pipelines and their runs in PostgreSQL.
+
+## Notes
+
+* Authentication and authorization should be integrated with Keycloak.
+* Message passing between functions can be orchestrated via Kafka.
+* Analytical data should be stored in a Delta Lake, while operational
+  metadata can be stored in PostgreSQL.

--- a/faas/bridge-api.yml
+++ b/faas/bridge-api.yml
@@ -1,0 +1,17 @@
+provider:
+  name: openfaas
+  gateway: http://127.0.0.1:8080
+functions:
+  bridge-api:
+    lang: python3
+    handler: ./faas/bridge-api
+    image: bridge-api:latest
+    environment:
+      write_timeout: 30s
+      read_timeout: 30s
+      KAFKA_BROKERS: "kafka:9092"
+      PIPELINE_TOPIC: "pipelines"
+  crawler:
+    lang: python3
+    handler: ./faas/crawler
+    image: data-crawler:latest

--- a/faas/bridge-api/handler.py
+++ b/faas/bridge-api/handler.py
@@ -1,0 +1,29 @@
+import os
+import yaml
+from kafka import KafkaProducer
+
+
+def handle(event, context):
+    """Entry point for bridge API.
+
+    Expects a YAML pipeline in the request body and publishes it to Kafka
+    for further processing. This function does not implement full
+    orchestration; it acts as a skeleton for future logic.
+    """
+    pipeline_yaml = event.body.decode('utf-8')
+    try:
+        pipeline = yaml.safe_load(pipeline_yaml)
+    except yaml.YAMLError as err:
+        return f"Invalid YAML: {err}"
+
+    kafka_servers = os.getenv("KAFKA_BROKERS", "kafka:9092").split(',')
+    topic = os.getenv("PIPELINE_TOPIC", "pipelines")
+
+    producer = KafkaProducer(bootstrap_servers=kafka_servers)
+    producer.send(topic, pipeline_yaml.encode('utf-8'))
+    producer.flush()
+
+    return {
+        "status": "accepted",
+        "pipeline": pipeline,
+    }

--- a/faas/bridge-api/requirements.txt
+++ b/faas/bridge-api/requirements.txt
@@ -1,0 +1,2 @@
+pyyaml
+kafka-python

--- a/faas/crawler/handler.py
+++ b/faas/crawler/handler.py
@@ -1,0 +1,13 @@
+import os
+import json
+
+
+def handle(event, context):
+    """Dummy crawler function.
+
+    This skeleton simulates a data crawler which would receive crawl
+    requests from Kafka or the orchestration layer. It simply returns a
+    placeholder response.
+    """
+    request = event.body.decode('utf-8')
+    return json.dumps({"status": "fetched", "request": request})

--- a/faas/crawler/requirements.txt
+++ b/faas/crawler/requirements.txt
@@ -1,0 +1,1 @@
+# Add crawler dependencies here

--- a/schema/postgres.sql
+++ b/schema/postgres.sql
@@ -1,0 +1,26 @@
+-- Schema for multi-tenant pipeline management
+
+CREATE TABLE tenants (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    keycloak_id UUID NOT NULL UNIQUE
+);
+
+CREATE TABLE pipelines (
+    id SERIAL PRIMARY KEY,
+    tenant_id INTEGER NOT NULL REFERENCES tenants(id),
+    name TEXT NOT NULL,
+    raw_yaml TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE pipeline_runs (
+    id SERIAL PRIMARY KEY,
+    pipeline_id INTEGER NOT NULL REFERENCES pipelines(id),
+    status TEXT NOT NULL,
+    started_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    finished_at TIMESTAMP
+);
+
+-- Index to speed up lookups by tenant
+CREATE INDEX idx_pipelines_tenant ON pipelines(tenant_id);


### PR DESCRIPTION
## Summary
- add OpenFaaS functions for a bridge API and crawler
- provide deployment manifest
- document the skeleton and how to deploy it
- create a Postgres schema for multi-tenant pipelines

## Testing
- `git status --short`