### PR TITLE
Add DB metadata stored procedures and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ faas-cli deploy -f faas/bridge-api.yml
 ## Database Schema
 
 The `schema/postgres.sql` file contains a simple schema for managing
-multi-tenant pipelines and their runs in PostgreSQL.
+multi-tenant pipelines and their runs in PostgreSQL. It also defines
+stored procedures used by the functions to persist pipeline metadata and
+log requests.
 
 ## Notes
 

--- a/faas/bridge-api/handler.py
+++ b/faas/bridge-api/handler.py
@@ -1,6 +1,7 @@
 import os
 import yaml
 from kafka import KafkaProducer
+from faas.common import db
 
 
 def handle(event, context):
@@ -10,20 +11,30 @@ def handle(event, context):
     for further processing. This function does not implement full
     orchestration; it acts as a skeleton for future logic.
     """
-    pipeline_yaml = event.body.decode('utf-8')
+    pipeline_yaml = event.body.decode("utf-8")
     try:
         pipeline = yaml.safe_load(pipeline_yaml)
     except yaml.YAMLError as err:
         return f"Invalid YAML: {err}"
 
+    tenant_id = int(os.getenv("DEFAULT_TENANT_ID", "1"))
+    pipeline_id = db.insert_pipeline_metadata(
+        tenant_id,
+        pipeline.get("name", "pipeline"),
+        pipeline_yaml,
+    )
+
     kafka_servers = os.getenv("KAFKA_BROKERS", "kafka:9092").split(',')
     topic = os.getenv("PIPELINE_TOPIC", "pipelines")
 
     producer = KafkaProducer(bootstrap_servers=kafka_servers)
-    producer.send(topic, pipeline_yaml.encode('utf-8'))
+    producer.send(topic, pipeline_yaml.encode("utf-8"))
     producer.flush()
+
+    db.log_request_run(pipeline_id, "bridge-api", {"status": "accepted"})
 
     return {
         "status": "accepted",
         "pipeline": pipeline,
+        "pipeline_id": pipeline_id,
     }

--- a/faas/bridge-api/requirements.txt
+++ b/faas/bridge-api/requirements.txt
@@ -1,2 +1,3 @@
 pyyaml
 kafka-python
+psycopg2-binary

--- a/faas/common/db.py
+++ b/faas/common/db.py
@@ -1,0 +1,54 @@
+import os
+import psycopg2
+from psycopg2 import extras
+
+
+def get_db_conn():
+    dsn = os.getenv(
+        "POSTGRES_DSN",
+        "dbname=pipeline user=postgres password=postgres host=postgres",
+    )
+    conn = psycopg2.connect(dsn)
+    conn.autocommit = True
+    return conn
+
+
+def insert_pipeline_metadata(tenant_id, name, raw_yaml):
+    with get_db_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT insert_pipeline_metadata(%s, %s, %s)",
+                (tenant_id, name, raw_yaml),
+            )
+            pipeline_id = cur.fetchone()[0]
+    return pipeline_id
+
+
+def get_pipeline_metadata(pipeline_id):
+    with get_db_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT * FROM get_pipeline_metadata(%s)",
+                (pipeline_id,),
+            )
+            row = cur.fetchone()
+    if row:
+        return {
+            "id": row[0],
+            "tenant_id": row[1],
+            "name": row[2],
+            "raw_yaml": row[3],
+            "created_at": row[4].isoformat() if row[4] else None,
+        }
+    return None
+
+
+def log_request_run(pipeline_id, func_name, details=None):
+    details_json = extras.Json(details) if details else None
+    with get_db_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT log_request_run(%s, %s, %s)",
+                (pipeline_id, func_name, details_json),
+            )
+

--- a/faas/crawler/handler.py
+++ b/faas/crawler/handler.py
@@ -1,5 +1,6 @@
 import os
 import json
+from faas.common import db
 
 
 def handle(event, context):
@@ -9,5 +10,11 @@ def handle(event, context):
     requests from Kafka or the orchestration layer. It simply returns a
     placeholder response.
     """
-    request = event.body.decode('utf-8')
-    return json.dumps({"status": "fetched", "request": request})
+    body = event.body.decode("utf-8")
+    try:
+        pipeline_id = int(body)
+    except ValueError:
+        return json.dumps({"status": "error", "message": "invalid pipeline id"})
+
+    metadata = db.get_pipeline_metadata(pipeline_id)
+    return json.dumps({"status": "fetched", "pipeline": metadata})

--- a/faas/crawler/requirements.txt
+++ b/faas/crawler/requirements.txt
@@ -1,1 +1,2 @@
 # Add crawler dependencies here
+psycopg2-binary

--- a/schema/postgres.sql
+++ b/schema/postgres.sql
@@ -24,3 +24,55 @@ CREATE TABLE pipeline_runs (
 
 -- Index to speed up lookups by tenant
 CREATE INDEX idx_pipelines_tenant ON pipelines(tenant_id);
+
+-- Table for storing request logs
+CREATE TABLE request_logs (
+    id SERIAL PRIMARY KEY,
+    pipeline_id INTEGER REFERENCES pipelines(id),
+    func_name TEXT NOT NULL,
+    details JSONB,
+    logged_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Stored procedure to insert pipeline metadata
+CREATE OR REPLACE FUNCTION insert_pipeline_metadata(
+    p_tenant_id INTEGER,
+    p_name TEXT,
+    p_raw_yaml TEXT
+) RETURNS INTEGER AS $$
+DECLARE
+    new_id INTEGER;
+BEGIN
+    INSERT INTO pipelines(tenant_id, name, raw_yaml)
+    VALUES (p_tenant_id, p_name, p_raw_yaml)
+    RETURNING id INTO new_id;
+    RETURN new_id;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Stored procedure to fetch pipeline metadata
+CREATE OR REPLACE FUNCTION get_pipeline_metadata(
+    p_id INTEGER
+) RETURNS TABLE(
+    id INTEGER,
+    tenant_id INTEGER,
+    name TEXT,
+    raw_yaml TEXT,
+    created_at TIMESTAMP
+) AS $$
+BEGIN
+    RETURN QUERY SELECT * FROM pipelines WHERE id = p_id;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Stored procedure to log request information
+CREATE OR REPLACE FUNCTION log_request_run(
+    p_pipeline_id INTEGER,
+    p_func_name TEXT,
+    p_details JSONB
+) RETURNS VOID AS $$
+BEGIN
+    INSERT INTO request_logs(pipeline_id, func_name, details)
+    VALUES (p_pipeline_id, p_func_name, p_details);
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary
- create stored procedures for inserting pipeline metadata, fetching it and logging requests
- implement shared DB helper module
- update bridge and crawler functions to use the new stored procedures
- log request completion from bridge API
- document stored procedures in README

## Testing
- `python3 -m py_compile faas/common/db.py faas/bridge-api/handler.py faas/crawler/handler.py`