### PR TITLE
Add fn-core-pipeline-registrar function

### DIFF
--- a/faas/fn-core-pipeline-registrar.yml
+++ b/faas/fn-core-pipeline-registrar.yml
@@ -1,0 +1,16 @@
+provider:
+  name: openfaas
+  gateway: http://127.0.0.1:8080
+functions:
+  fn-core-pipeline-registrar:
+    lang: python3
+    handler: ./faas/fn-core-pipeline-registrar
+    image: fn-core-pipeline-registrar:latest
+    environment:
+      write_timeout: 30s
+      read_timeout: 30s
+      DELTA_PATH: "/tmp/delta"
+      WORKSPACE_ID: "default"
+      TRACE_PREFIX: "trace"
+      KAFKA_BROKERS: "kafka:9092"
+      PIPELINE_TOPIC: "registered-pipelines"

--- a/faas/fn-core-pipeline-registrar/env.json
+++ b/faas/fn-core-pipeline-registrar/env.json
@@ -1,0 +1,7 @@
+{
+  "DELTA_PATH": "/tmp/delta",
+  "WORKSPACE_ID": "default",
+  "TRACE_PREFIX": "trace",
+  "KAFKA_BROKERS": "kafka:9092",
+  "PIPELINE_TOPIC": "registered-pipelines"
+}

--- a/faas/fn-core-pipeline-registrar/handler.py
+++ b/faas/fn-core-pipeline-registrar/handler.py
@@ -1,0 +1,75 @@
+import os
+import json
+import uuid
+from datetime import datetime
+
+import yaml
+from confluent_kafka import Producer
+
+try:
+    from delta import configure_spark_with_delta_pip
+    from pyspark.sql import SparkSession
+except Exception:  # noqa: E722
+    configure_spark_with_delta_pip = None
+    SparkSession = None
+
+
+def save_to_delta(pipeline_yaml: str, job_id: str, trace_id: str) -> None:
+    """Append the pipeline specification to a Delta Lake table."""
+    delta_path = os.getenv("DELTA_PATH", "/tmp/delta")
+    workspace_id = os.getenv("WORKSPACE_ID", "default")
+    target_path = os.path.join(delta_path, workspace_id)
+
+    if SparkSession is None:
+        # Delta libraries are not available; skip persistence
+        return
+
+    builder = SparkSession.builder.appName("pipeline-registrar")
+    if configure_spark_with_delta_pip:
+        builder = configure_spark_with_delta_pip(builder)
+    spark = builder.getOrCreate()
+    df = spark.createDataFrame([
+        {
+            "job_id": job_id,
+            "trace_id": trace_id,
+            "pipeline_yaml": pipeline_yaml,
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+    ])
+    df.write.format("delta").mode("append").save(target_path)
+    spark.stop()
+
+
+def handle(event, context):  # noqa: D401
+    """Register a pipeline specification."""
+    body = event.body.decode("utf-8")
+    try:
+        pipeline = yaml.safe_load(body)
+    except yaml.YAMLError as err:
+        return json.dumps({"status": "error", "message": f"Invalid YAML: {err}"})
+
+    job_id = str(uuid.uuid4())
+    trace_prefix = os.getenv("TRACE_PREFIX", "trace")
+    trace_id = f"{trace_prefix}-{uuid.uuid4()}"
+
+    save_to_delta(body, job_id, trace_id)
+
+    kafka_brokers = os.getenv("KAFKA_BROKERS", "kafka:9092")
+    topic = os.getenv("PIPELINE_TOPIC", "registered-pipelines")
+    producer = Producer({"bootstrap.servers": kafka_brokers})
+    message = json.dumps({
+        "pipeline": pipeline,
+        "job_id": job_id,
+        "trace_id": trace_id,
+    })
+    producer.produce(topic, message.encode("utf-8"))
+    producer.flush()
+
+    pipeline_id = pipeline.get("id", job_id)
+
+    return json.dumps({
+        "status": "registered",
+        "trace_id": trace_id,
+        "job_id": job_id,
+        "pipeline_id": pipeline_id,
+    })

--- a/faas/fn-core-pipeline-registrar/requirements.txt
+++ b/faas/fn-core-pipeline-registrar/requirements.txt
@@ -1,0 +1,5 @@
+pyyaml
+confluent-kafka
+delta-spark
+uuid
+datetime


### PR DESCRIPTION
## Summary
- add fn-core-pipeline-registrar function
- allow registering pipelines into Delta Lake
- publish pipeline metadata to Kafka
- wire up OpenFaaS deployment config

## Testing
- `python -m py_compile faas/fn-core-pipeline-registrar/handler.py`