### PR TITLE
Switch bridge api to confluent kafka

### DIFF
--- a/faas/bridge-api/handler.py
+++ b/faas/bridge-api/handler.py
@@ -1,6 +1,6 @@
 import os
 import yaml
-from kafka import KafkaProducer
+from confluent_kafka import Producer
 from faas.common import db
 
 
@@ -24,11 +24,11 @@ def handle(event, context):
         pipeline_yaml,
     )
 
-    kafka_servers = os.getenv("KAFKA_BROKERS", "kafka:9092").split(',')
+    kafka_servers = os.getenv("KAFKA_BROKERS", "kafka:9092")
     topic = os.getenv("PIPELINE_TOPIC", "pipelines")
 
-    producer = KafkaProducer(bootstrap_servers=kafka_servers)
-    producer.send(topic, pipeline_yaml.encode("utf-8"))
+    producer = Producer({"bootstrap.servers": kafka_servers})
+    producer.produce(topic, pipeline_yaml.encode("utf-8"))
     producer.flush()
 
     db.log_request_run(pipeline_id, "bridge-api", {"status": "accepted"})

--- a/faas/bridge-api/requirements.txt
+++ b/faas/bridge-api/requirements.txt
@@ -1,3 +1,3 @@
 pyyaml
-kafka-python
+confluent-kafka
 psycopg2-binary


### PR DESCRIPTION
## Summary
- replace `kafka-python` with `confluent-kafka`
- update bridge API to use `confluent_kafka.Producer`

## Testing
- `python -m py_compile faas/bridge-api/handler.py`