### PR TITLE
Add env.json config loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,23 @@ Deploy both functions using the OpenFaaS CLI:
 faas-cli deploy -f faas/bridge-api.yml
 ```
 
+## Configuration
+
+Functions read their settings from environment variables. When running
+locally, you can create an `env.json` file in the repository root containing
+key/value pairs. Values in `env.json` are merged with `os.environ` and can be
+retrieved in code via `faas.common.config.get_setting`.
+
+Example `env.json`:
+
+```json
+{
+  "KAFKA_BROKERS": "localhost:9092",
+  "PIPELINE_TOPIC": "pipelines",
+  "POSTGRES_DSN": "dbname=pipeline user=postgres password=postgres host=localhost"
+}
+```
+
 ## Database Schema
 
 The `schema/postgres.sql` file contains a simple schema for managing

--- a/faas/bridge-api/handler.py
+++ b/faas/bridge-api/handler.py
@@ -1,7 +1,7 @@
-import os
 import yaml
 from kafka import KafkaProducer
 from faas.common import db
+from faas.common.config import get_setting
 
 
 def handle(event, context):
@@ -17,15 +17,15 @@ def handle(event, context):
     except yaml.YAMLError as err:
         return f"Invalid YAML: {err}"
 
-    tenant_id = int(os.getenv("DEFAULT_TENANT_ID", "1"))
+    tenant_id = int(get_setting("DEFAULT_TENANT_ID", "1"))
     pipeline_id = db.insert_pipeline_metadata(
         tenant_id,
         pipeline.get("name", "pipeline"),
         pipeline_yaml,
     )
 
-    kafka_servers = os.getenv("KAFKA_BROKERS", "kafka:9092").split(',')
-    topic = os.getenv("PIPELINE_TOPIC", "pipelines")
+    kafka_servers = get_setting("KAFKA_BROKERS", "kafka:9092").split(',')
+    topic = get_setting("PIPELINE_TOPIC", "pipelines")
 
     producer = KafkaProducer(bootstrap_servers=kafka_servers)
     producer.send(topic, pipeline_yaml.encode("utf-8"))

--- a/faas/common/config.py
+++ b/faas/common/config.py
@@ -1,0 +1,28 @@
+import json
+import os
+from pathlib import Path
+
+
+def load_settings():
+    """Load settings from env.json if present and merge with environment variables."""
+    settings = {}
+    env_path = Path('env.json')
+    if env_path.exists():
+        try:
+            with env_path.open() as f:
+                data = json.load(f)
+                if isinstance(data, dict):
+                    settings.update({str(k): str(v) for k, v in data.items()})
+        except json.JSONDecodeError:
+            pass
+    # Environment variables override entries in env.json
+    settings.update(os.environ)
+    return settings
+
+
+_SETTINGS = load_settings()
+
+
+def get_setting(name, default=None):
+    """Retrieve a configuration value."""
+    return _SETTINGS.get(name, default)

--- a/faas/common/db.py
+++ b/faas/common/db.py
@@ -1,10 +1,10 @@
-import os
 import psycopg2
 from psycopg2 import extras
+from .config import get_setting
 
 
 def get_db_conn():
-    dsn = os.getenv(
+    dsn = get_setting(
         "POSTGRES_DSN",
         "dbname=pipeline user=postgres password=postgres host=postgres",
     )


### PR DESCRIPTION
## Summary
- add config loader that merges `env.json` and `os.environ`
- update DB and Bridge API to use new loader
- document configuration via `env.json`

## Testing
- `python -m py_compile faas/common/config.py faas/common/db.py faas/bridge-api/handler.py faas/crawler/handler.py`